### PR TITLE
Set maximum size for loading splash screen icons

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -2,8 +2,8 @@ import { LoadingLayer } from "@/components/layouts/Loading";
 
 export default function Loading() {
   return (
-    <div className="w-full h-screen overflow-clip">
+    <main className="relative w-full h-screen overflow-clip">
       <LoadingLayer />
-    </div>
+    </main>
   );
 }

--- a/src/components/layouts/Loading.tsx
+++ b/src/components/layouts/Loading.tsx
@@ -14,7 +14,7 @@ export function LoadingLayer({ working = true }: LoadingIconProps) {
     <div
       className={styles.overlay + `${working ? " opacity-100 visible" : " opacity-0 invisible"}`}
     >
-      <div className="w-1/5 aspect-square">
+      <div className="w-1/5 max-w-[6rem] aspect-square">
         <LoadingPlayer />
       </div>
     </div>


### PR DESCRIPTION
- [Set maximum size for loading splash screen icons](https://github.com/wiyco/imap/commit/a0ff42e19931c7cfa6d3829f375ebfc18d830e5e)
- [Fix for correct element structure](https://github.com/wiyco/imap/commit/bf8fc14100e07a67e881cd93218b52879736842b)