### PR TITLE
Enhance the extensibility of the 'border-round-button`

### DIFF
--- a/src/app/test/border-round-button/page.tsx
+++ b/src/app/test/border-round-button/page.tsx
@@ -9,8 +9,14 @@ export default function Test() {
 
   return (
     <div className="grid h-screen place-items-center gap-6 p-6">
-      <BorderRoundButton title="Sign In" fontSize="text-2xl" onClick={check} />
-      <BorderRoundButton title="次へ" onClick={check} />
+      <div className="w-3/4">
+        <BorderRoundButton fontSize="text-3xl" onClick={check}>
+          Sign In
+        </BorderRoundButton>
+      </div>
+      <div className="w-24">
+        <BorderRoundButton onClick={check}>次へ</BorderRoundButton>
+      </div>
     </div>
   );
 }

--- a/src/components/buttons/BorderRoundButton/index.tsx
+++ b/src/components/buttons/BorderRoundButton/index.tsx
@@ -3,7 +3,7 @@
 import styles from "./styles.module.scss";
 
 type BorderRoundButtonProps = {
-  title: string;
+  children: React.ReactNode;
   fontSize?:
     | "text-xs"
     | "text-sm"
@@ -21,11 +21,11 @@ type BorderRoundButtonProps = {
   onClick: () => void;
 };
 
-export function BorderRoundButton({ title, fontSize, onClick }: BorderRoundButtonProps) {
+export function BorderRoundButton({ children, fontSize, onClick }: BorderRoundButtonProps) {
   return (
     <button className={`${styles.container} ${fontSize}`} onClick={onClick}>
       <div className={styles.inner}>
-        <span className={styles.title}>{title}</span>
+        <span className={styles.title}>{children}</span>
       </div>
     </button>
   );

--- a/src/components/buttons/BorderRoundButton/styles.module.scss
+++ b/src/components/buttons/BorderRoundButton/styles.module.scss
@@ -1,7 +1,7 @@
 @use "variables" as var;
 
 .container {
-  @apply relative h-fit w-fit
+  @apply relative h-fit w-full
     overflow-clip;
 
   padding: 0.25em; // p-1
@@ -9,8 +9,7 @@
   border-radius: 1.5em; // rounded-3xl
 
   & > .inner {
-    @apply flex items-center justify-center
-      rounded-3xl;
+    @apply flex items-center justify-center;
 
     padding: 0.25em 1.5em; // py-1 px-6
     background-color: #fff;


### PR DESCRIPTION
- `title: string` prop to `children: ReactNode`
- `width`